### PR TITLE
refactor tensorboard logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,13 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 ### Added
 - Added a verbose level (options are now 0,1,2) which will print progress for the entire fit call, updating every epoch. Useful when doing dynamic programming with little data.
 - Added support for dictionary outputs of dataloader
+- Added abstract superclass for building TensorBoardX based callbacks
 ### Changed
 - Timer callback can now also be used as a metric which allows display of specified timings to printers and has been moved to metrics.
 - The loss_criterion is renamed to criterion in `torchbearer.Model` arguments.
 - The criterion in `torchbearer.Model` is now optional and will provide a zero loss tensor if it is not given.
+- TensorBoard callbacks refactored to be based on a common super class
+- TensorBoard callbacks refactored to use a common `SummaryWriter` for each log directory
 ### Deprecated
 ### Removed
 ### Fixed

--- a/torchbearer/callbacks/tensor_board.py
+++ b/torchbearer/callbacks/tensor_board.py
@@ -22,7 +22,7 @@ def get_writer(log_dir, logger) -> SummaryWriter:
     :return: the `SummaryWriter` object
     """
     if log_dir not in __writers__:
-        __writers__[log_dir] = {'writer': SummaryWriter(log_dir), 'references': set()}
+        __writers__[log_dir] = {'writer': SummaryWriter(log_dir=log_dir), 'references': set()}
 
     __writers__[log_dir]['references'].add(logger)
     return __writers__[log_dir]['writer']
@@ -166,9 +166,8 @@ class TensorBoard(AbstractTensorBoard):
             self.close_writer(self.batch_log_dir)
 
         if self.write_epoch_metrics:
-            writer = self.get_writer()
             for metric in state[torchbearer.METRICS]:
-                writer.add_scalar('epoch/' + metric, state[torchbearer.METRICS][metric], state[torchbearer.EPOCH])
+                self.writer.add_scalar('epoch/' + metric, state[torchbearer.METRICS][metric], state[torchbearer.EPOCH])
 
 
 class TensorBoardImages(AbstractTensorBoard):


### PR DESCRIPTION
I've refactored the tensorboard logging:

- there is less code duplication
- writers are now shared, so if you use multiple TensorBoard* callbacks working in the same directory they'll all use the same underlying SummaryWriter (the instance of which is referenced-counted and will close at the right time)
- it should now be much easier to write custom tensorboard logging callbacks