### PR TITLE
Add data_key selection to evaluate and predict methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 ### Added
+- Evaluation and prediction can now be done on any data using data_key keywork arg
 ### Changed
 ### Deprecated
 ### Removed

--- a/tests/test_trial.py
+++ b/tests/test_trial.py
@@ -727,7 +727,7 @@ class TestFitPass(TestCase):
 
         torchbearertrial = Trial(torchmodel, optimizer, criterion, [], callbacks=[], pass_state=False)
         torchbearertrial.train = Mock()
-        torchbearertrial.state = {tb.TRAIN_GENERATOR: generator, tb.CALLBACK_LIST: callback_list}
+        torchbearertrial.state = {tb.TRAIN_GENERATOR: generator, tb.CALLBACK_LIST: callback_list, tb.TRAIN_DATA: (generator, train_steps)}
 
         torchbearertrial._fit_pass(state)
         self.assertEqual(torchbearertrial.train.call_count, 1)
@@ -755,7 +755,7 @@ class TestFitPass(TestCase):
 
         torchbearertrial = Trial(torchmodel, optimizer, criterion, [], callbacks=[], pass_state=False)
         torchbearertrial.train = Mock()
-        torchbearertrial.state = {tb.TRAIN_GENERATOR: generator, tb.CALLBACK_LIST: callback_list}
+        torchbearertrial.state = {tb.TRAIN_GENERATOR: generator, tb.CALLBACK_LIST: callback_list, tb.TRAIN_DATA: (generator, train_steps)}
 
         torchbearertrial._fit_pass(state)
         self.assertEqual(metric_list.reset.call_count, 1)
@@ -785,7 +785,7 @@ class TestFitPass(TestCase):
 
         torchbearertrial = Trial(torchmodel, optimizer, criterion, [], callbacks=[], pass_state=False)
         torchbearertrial.train = Mock()
-        torchbearertrial.state = {tb.TRAIN_GENERATOR: generator, tb.CALLBACK_LIST: callback_list}
+        torchbearertrial.state = {tb.TRAIN_GENERATOR: generator, tb.CALLBACK_LIST: callback_list, tb.TRAIN_DATA: (generator, train_steps)}
 
         torchbearertrial._fit_pass(state)
         self.assertEqual(callback_list.on_start_training.call_count, 1)
@@ -821,7 +821,7 @@ class TestFitPass(TestCase):
 
         torchbearertrial = Trial(torchmodel, optimizer, criterion, [], callbacks=[], pass_state=False)
         torchbearertrial.train = Mock()
-        torchbearertrial.state = {tb.TRAIN_GENERATOR: generator, tb.CALLBACK_LIST: callback_list}
+        torchbearertrial.state = {tb.TRAIN_GENERATOR: generator, tb.CALLBACK_LIST: callback_list, tb.TRAIN_DATA: (generator, train_steps)}
 
         torchbearertrial._fit_pass(state)
         self.assertTrue(optimizer.zero_grad.call_count == 3)
@@ -853,7 +853,7 @@ class TestFitPass(TestCase):
         torchbearertrial = Trial(torchmodel, optimizer, criterion, [], callbacks=[], pass_state=False)
         torchbearertrial.train = Mock()
         torchbearertrial.pass_state = False
-        torchbearertrial.state = {tb.TRAIN_GENERATOR: generator, tb.CALLBACK_LIST: callback_list}
+        torchbearertrial.state = {tb.TRAIN_GENERATOR: generator, tb.CALLBACK_LIST: callback_list, tb.TRAIN_DATA: (generator, train_steps)}
 
         torchbearertrial._fit_pass(state)
         self.assertTrue(torchmodel.call_count == 3)
@@ -888,7 +888,7 @@ class TestFitPass(TestCase):
         torchbearertrial = Trial(torchmodel, optimizer, criterion, [], callbacks=[], pass_state=False)
         torchbearertrial.train = Mock()
         torchbearertrial.pass_state = True
-        torchbearertrial.state = {tb.TRAIN_GENERATOR: generator, tb.CALLBACK_LIST: callback_list}
+        torchbearertrial.state = {tb.TRAIN_GENERATOR: generator, tb.CALLBACK_LIST: callback_list, tb.TRAIN_DATA: (generator, train_steps)}
 
         torchbearertrial._fit_pass(state)
         self.assertTrue(torchmodel.call_count == 3)
@@ -924,13 +924,12 @@ class TestFitPass(TestCase):
         torchbearertrial = Trial(torchmodel, optimizer, criterion, [], callbacks=[], pass_state=False)
         torchbearertrial.train = Mock()
         torchbearertrial.pass_state = True
-        torchbearertrial.state = {tb.TRAIN_GENERATOR: generator, tb.CALLBACK_LIST: callback_list}
+        torchbearertrial.state = {tb.TRAIN_GENERATOR: generator, tb.CALLBACK_LIST: callback_list, tb.TRAIN_DATA: (generator, train_steps)}
 
         torchbearertrial._fit_pass(state)
         self.assertTrue(criterion.call_count == 3)
         self.assertTrue(criterion.call_args_list[0][0][0] == 5)
         self.assertTrue(criterion.call_args_list[0][0][1].item() == 1.0)
-
 
     def test_fit_backward(self):
         data = [(torch.Tensor([1]), torch.Tensor([1])), (torch.Tensor([2]), torch.Tensor([2])),
@@ -962,7 +961,7 @@ class TestFitPass(TestCase):
         torchbearertrial = Trial(torchmodel, optimizer, criterion, [], callbacks=[], pass_state=False)
         torchbearertrial.train = Mock()
         torchbearertrial.pass_state = True
-        torchbearertrial.state = {tb.TRAIN_GENERATOR: generator, tb.CALLBACK_LIST: callback_list}
+        torchbearertrial.state = {tb.TRAIN_GENERATOR: generator, tb.CALLBACK_LIST: callback_list, tb.TRAIN_DATA: (generator, train_steps)}
 
         torchbearertrial._fit_pass(state)
         self.assertTrue(loss.backward.call_count == 3)
@@ -995,7 +994,7 @@ class TestFitPass(TestCase):
         torchbearertrial = Trial(torchmodel, optimizer, criterion, [], callbacks=[], pass_state=False)
         torchbearertrial.train = Mock()
         torchbearertrial.pass_state = True
-        torchbearertrial.state = {tb.TRAIN_GENERATOR: generator, tb.CALLBACK_LIST: callback_list}
+        torchbearertrial.state = {tb.TRAIN_GENERATOR: generator, tb.CALLBACK_LIST: callback_list, tb.TRAIN_DATA: (generator, train_steps)}
 
         torchbearertrial._fit_pass(state)
         self.assertTrue(metric_list.process.call_count == 3)
@@ -1030,7 +1029,7 @@ class TestFitPass(TestCase):
         torchbearertrial = Trial(torchmodel, optimizer, criterion, [], callbacks=[], pass_state=False)
         torchbearertrial.train = Mock()
         torchbearertrial.pass_state = True
-        torchbearertrial.state = {tb.TRAIN_GENERATOR: generator, tb.CALLBACK_LIST: callback_list}
+        torchbearertrial.state = {tb.TRAIN_GENERATOR: generator, tb.CALLBACK_LIST: callback_list, tb.TRAIN_DATA: (generator, train_steps)}
 
         history = torchbearertrial._fit_pass(state)[tb.METRICS]
         self.assertEqual(metric_list.process_final.call_count, 1)
@@ -1066,7 +1065,7 @@ class TestFitPass(TestCase):
         torchbearertrial = Trial(torchmodel, optimizer, criterion, [], callbacks=[], pass_state=False)
         torchbearertrial.train = Mock()
         torchbearertrial.pass_state = True
-        torchbearertrial.state = {tb.TRAIN_GENERATOR: generator, tb.CALLBACK_LIST: callback_list}
+        torchbearertrial.state = {tb.TRAIN_GENERATOR: generator, tb.CALLBACK_LIST: callback_list, tb.TRAIN_DATA: (generator, train_steps)}
 
         torchbearertrial._fit_pass(state)
         self.assertEqual(metric_list.process.call_count, 1)
@@ -1101,7 +1100,7 @@ class TestFitPass(TestCase):
         torchbearertrial = Trial(torchmodel, optimizer, criterion, [], callbacks=[], pass_state=False)
         torchbearertrial.train = Mock()
         torchbearertrial.pass_state = False
-        torchbearertrial.state = {tb.TRAIN_GENERATOR: None, tb.CALLBACK_LIST: callback_list}
+        torchbearertrial.state = {tb.TRAIN_GENERATOR: None, tb.CALLBACK_LIST: callback_list, tb.TRAIN_DATA: (None, steps)}
 
         state = torchbearertrial._fit_pass(state)
         self.assertTrue(state[tb.ITERATOR] is None)
@@ -1138,7 +1137,7 @@ class TestFitPass(TestCase):
         torchbearertrial = Trial(torchmodel, optimizer, criterion, [], callbacks=[], pass_state=False)
         torchbearertrial.train = Mock()
         torchbearertrial.pass_state = False
-        torchbearertrial.state = {tb.TRAIN_GENERATOR: generator, tb.CALLBACK_LIST: callback_list}
+        torchbearertrial.state = {tb.TRAIN_GENERATOR: generator, tb.CALLBACK_LIST: callback_list, tb.TRAIN_DATA: (generator, steps)}
 
         state = torchbearertrial._fit_pass(state)
         self.assertTrue(state[tb.ITERATOR] is not None)
@@ -1522,7 +1521,7 @@ class TestTrialValEvalPred(TestCase):
         t = Trial(MagicMock())
         eval_mock = t.eval = Mock()
         test_pass_mock = t._test_pass = Mock()
-        t.state = {tb.VALIDATION_GENERATOR: generator, tb.CALLBACK_LIST: None}
+        t.state = {tb.VALIDATION_GENERATOR: generator, tb.CALLBACK_LIST: None, tb.VALIDATION_DATA: (generator, steps)}
         metrics = t._validation_pass(state)
 
         self.assertEqual(eval_mock.call_count, 1)
@@ -1541,7 +1540,7 @@ class TestTrialValEvalPred(TestCase):
         t = Trial(MagicMock())
         eval_mock = t.eval = Mock()
         t._test_pass = Mock()
-        t.state = {tb.VALIDATION_GENERATOR: generator, tb.CALLBACK_LIST: None}
+        t.state = {tb.VALIDATION_GENERATOR: generator, tb.CALLBACK_LIST: None, tb.VALIDATION_DATA: (generator, steps)}
         t._validation_pass(state)
 
         self.assertTrue(eval_mock.call_count == 0)
@@ -1555,7 +1554,7 @@ class TestTrialValEvalPred(TestCase):
         t = Trial(MagicMock())
         eval_mock = t.eval = Mock()
         test_pass_mock = t._test_pass = Mock(return_value={tb.METRICS: 1})
-        t.state = {tb.VALIDATION_GENERATOR: generator, tb.CALLBACK_LIST: None, tb.VALIDATION_STEPS: steps}
+        t.state = {tb.VALIDATION_GENERATOR: generator, tb.CALLBACK_LIST: None, tb.VALIDATION_STEPS: steps, tb.VALIDATION_DATA: (generator, steps)}
         metrics = t.evaluate(state)
 
         self.assertEqual(eval_mock.call_count, 1)
@@ -1574,7 +1573,7 @@ class TestTrialValEvalPred(TestCase):
         t = Trial(MagicMock())
         eval_mock = t.eval = Mock()
         test_pass_mock = t._test_pass = Mock(return_value={tb.METRICS: 1})
-        t.state = {tb.VALIDATION_GENERATOR: generator, tb.CALLBACK_LIST: None, tb.VALIDATION_STEPS: steps}
+        t.state = {tb.VALIDATION_GENERATOR: generator, tb.CALLBACK_LIST: None, tb.VALIDATION_STEPS: steps, tb.VALIDATION_DATA: (generator, steps)}
         metrics = t.evaluate(state)
 
         self.assertTrue(eval_mock.call_count == 0)
@@ -1588,7 +1587,7 @@ class TestTrialValEvalPred(TestCase):
         t = Trial(MagicMock())
         eval_mock = t.eval = Mock()
         test_pass_mock = t._test_pass = Mock(return_value={tb.FINAL_PREDICTIONS: 1})
-        t.state = {tb.TEST_GENERATOR: generator, tb.CALLBACK_LIST: None, tb.TEST_STEPS: steps}
+        t.state = {tb.TEST_GENERATOR: generator, tb.CALLBACK_LIST: None, tb.TEST_STEPS: steps, tb.TEST_DATA: (generator, steps)}
         metrics = t.predict(state)
 
         self.assertEqual(eval_mock.call_count, 1)
@@ -1607,7 +1606,7 @@ class TestTrialValEvalPred(TestCase):
         t = Trial(MagicMock())
         eval_mock = t.eval = Mock()
         test_pass_mock = t._test_pass = Mock(return_value={tb.FINAL_PREDICTIONS: 1})
-        t.state = {tb.TEST_GENERATOR: generator, tb.CALLBACK_LIST: None, tb.TEST_STEPS: steps}
+        t.state = {tb.TEST_GENERATOR: generator, tb.CALLBACK_LIST: None, tb.TEST_STEPS: steps, tb.TEST_DATA: (generator, steps)}
         metrics = t.predict(state)
 
         self.assertTrue(eval_mock.call_count == 0)
@@ -2059,6 +2058,7 @@ class TestTrialFunctions(TestCase):
 
     def test_inject_sampler_standard(self):
         generator = MagicMock()
+        steps = None
 
         class SomeClass:
             @tb.inject_sampler(tb.GENERATOR)
@@ -2066,12 +2066,13 @@ class TestTrialFunctions(TestCase):
                 pass
 
         t = SomeClass()
-        t.state = {tb.GENERATOR: generator}
+        t.state = {tb.GENERATOR: (generator, steps)}
         t.test_func()
         self.assertTrue(t.state[tb.SAMPLER].batch_loader == tb.trial.load_batch_standard)
 
     def test_inject_sampler_none(self):
         generator = None
+        steps = None
 
         class SomeClass:
             @tb.inject_sampler(tb.GENERATOR)
@@ -2079,12 +2080,13 @@ class TestTrialFunctions(TestCase):
                 pass
 
         t = SomeClass()
-        t.state = {tb.GENERATOR: generator}
+        t.state = {tb.GENERATOR: (generator, steps)}
         t.test_func()
         self.assertTrue(t.state[tb.SAMPLER].batch_loader == tb.trial.load_batch_none)
 
     def test_inject_sampler_predict(self):
         generator = MagicMock()
+        steps = None
 
         class SomeClass:
             @tb.inject_sampler(tb.GENERATOR, predict=True)
@@ -2092,9 +2094,25 @@ class TestTrialFunctions(TestCase):
                 pass
 
         t = SomeClass()
-        t.state = {tb.GENERATOR: generator}
+        t.state = {tb.GENERATOR: (generator, steps)}
         t.test_func()
         self.assertTrue(t.state[tb.SAMPLER].batch_loader == tb.trial.load_batch_predict)
+
+    def test_inject_sampler_data_key(self):
+        generator = MagicMock()
+        test_generator = 'test'
+        test_steps = 1
+
+        class SomeClass:
+            @tb.inject_sampler(tb.GENERATOR, predict=False)
+            def test_func(self, data_key=None):
+                pass
+
+        t = SomeClass()
+        t.state = {tb.GENERATOR: (generator, None), tb.TEST_GENERATOR: (test_generator, test_steps)}
+        t.test_func(data_key=tb.TEST_GENERATOR)
+        self.assertTrue(t.state[tb.GENERATOR] == test_generator)
+        self.assertTrue(t.state[tb.STEPS] == test_steps)
 
     @patch('torchbearer.trial.CallbackListInjection')
     def test_inject_callback(self, c_inj):

--- a/torchbearer/state.py
+++ b/torchbearer/state.py
@@ -94,12 +94,15 @@ STEPS = state_key('steps')
 
 TRAIN_GENERATOR = state_key('train_generator')
 TRAIN_STEPS = state_key('train_steps')
+TRAIN_DATA = state_key('train_data')
 
 VALIDATION_GENERATOR = state_key('validation_generator')
 VALIDATION_STEPS = state_key('validation_steps')
+VALIDATION_DATA = state_key('validation_data')
 
 TEST_GENERATOR = state_key('test_generator')
 TEST_STEPS = state_key('test_steps')
+TEST_DATA = state_key('test_data')
 
 STOP_TRAINING = state_key('stop_training')
 Y_TRUE = state_key('y_true')

--- a/torchbearer/trial.py
+++ b/torchbearer/trial.py
@@ -189,9 +189,8 @@ class Sampler:
 
 def inject_sampler(data_key, predict=False):
     """ Decorator to inject a :class:`Sampler` into state[torchbearer.SAMPLER]
-
-    :param generator: The data generator for the sampler to load data from
-    :type generator: DataLoader
+    :param data_key: Key for the data to inject
+    :type data_key: StateKey
     :param predict: If true, the prediction batch loader is used, if false the standard data loader is used
     :type predict: bool
     :return: the decorator
@@ -692,6 +691,8 @@ class Trial(object):
 
         :param verbose: If 2: use tqdm on batch, If 1: use tqdm on epoch, Else: display no training progress
         :type verbose: int
+        :param data_key: Optional key for the data to evaluate on. Default: torchbearer.VALIDATION_DATA
+        :type data_key: StateKey
         :return: The final metric values
         :rtype: dict
         """
@@ -717,6 +718,8 @@ class Trial(object):
 
         :param verbose: If 2: use tqdm on batch, If 1: use tqdm on epoch, Else: display no training progress
         :type verbose: int
+        :param data_key: Optional key for the data to predict on. Default: torchbearer.TEST_DATA
+        :type data_key: StateKey
         :return: Model outputs as a list
         :rtype: list
         """

--- a/torchbearer/trial.py
+++ b/torchbearer/trial.py
@@ -188,7 +188,7 @@ class Sampler:
 
 
 def inject_sampler(data_key, predict=False):
-    """ Decorator to inject a :class:`Sampler` into state[torchbearer.SAMPLER]
+    """ Decorator to inject a :class:`Sampler` into state[torchbearer.SAMPLER] along with the associated generator and number of steps
     :param data_key: Key for the data to inject
     :type data_key: StateKey
     :param predict: If true, the prediction batch loader is used, if false the standard data loader is used

--- a/torchbearer/trial.py
+++ b/torchbearer/trial.py
@@ -188,7 +188,8 @@ class Sampler:
 
 
 def inject_sampler(data_key, predict=False):
-    """ Decorator to inject a :class:`Sampler` into state[torchbearer.SAMPLER] along with the associated generator and number of steps
+    """ Decorator to inject a :class:`Sampler` into state[torchbearer.SAMPLER] along with the specified \
+        generator into state[torchbearer.GENERATOR] and number of steps into state[torchbearer.STEPS]
     :param data_key: Key for the data to inject
     :type data_key: StateKey
     :param predict: If true, the prediction batch loader is used, if false the standard data loader is used

--- a/torchbearer/trial.py
+++ b/torchbearer/trial.py
@@ -220,16 +220,6 @@ def inject_sampler(data_key, predict=False):
     return decorator
 
 
-def get_sampler(state, generator, predict=False):
-    if state[generator] is None:
-        loader = load_batch_none
-    elif predict:
-        loader = load_batch_predict
-    else:
-        loader = load_batch_standard
-    return Sampler(loader)
-
-
 def inject_callback(callback):
     """ Decorator to inject a callback into the callback list and remove the callback after the decorated function has executed
     


### PR DESCRIPTION
What do you think about this @ethanwharris:
Inject sampler now takes a DATA key which is a tuple of the generator and steps for that generator and sets the GENERATOR and STEPS keys in state. Otherwise we would have to take both a generator key and a steps key in the evaluate and predict methods. 

I think the DATA keys (TRAIN_DATA, etc) need to be renamed though, since they are a (generator, steps) pair and not actually data. Would be nice if we could avoid the data keys being a tuple entirely though. 

Closes #374 

