### PR TITLE
Feature/trial verbose

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 ### Added
 - The default_for_key metric decorator can now be used to pass arguments to the init of the inner metric
 - The default metric for the key 'top_10_acc' is now the TopKCategoricalAccuracy metric with k set to 10
+- Global verbose flag for trial that can be overridden by run, evaluate, predict
 ### Changed
 ### Deprecated
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 ### Added
 - The default_for_key metric decorator can now be used to pass arguments to the init of the inner metric
 - The default metric for the key 'top_10_acc' is now the TopKCategoricalAccuracy metric with k set to 10
-- Global verbose flag for trial that can be overridden by run, evaluate, predict
+- Added global verbose flag for trial that can be overridden by run, evaluate, predict
 ### Changed
 ### Deprecated
 ### Removed

--- a/torchbearer/trial.py
+++ b/torchbearer/trial.py
@@ -294,6 +294,8 @@ class Trial(object):
     :type callbacks: list
     :param pass_state: If True, the torchbearer state will be passed to the model during fitting
     :type pass_state: bool
+    :param verbose: Global verbosity .If 2: use tqdm on batch, If 1: use tqdm on epoch, If 0: display no training progress
+    :type verbose: int
     """
     def __init__(self, model, optimizer=None, criterion=None, metrics=[], callbacks=[], pass_state=False, verbose=2):
         if criterion is None:


### PR DESCRIPTION
Closes #373 

Adds a global verbosity to Trial init and run, evaluate and predict use this if they take value -1, which is now the default. 
I've left replay verbosity as before since I feel like if you're replaying then you'll probably want to specify the verbosity. 