### PR TITLE
Remove "most_recent" from checkpointer state dicts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 ## [Unreleased]
 ### Added
 ### Changed
+- When resuming training checkpoitners no longer delete the state file the trial was loaded from
 ### Deprecated
 ### Removed
 ### Fixed

--- a/tests/callbacks/test_checkpointers.py
+++ b/tests/callbacks/test_checkpointers.py
@@ -118,17 +118,6 @@ class TestCheckpointer(TestCase):
         check.save_checkpoint(state, True)
         self.assertTrue(check.most_recent == 'test_file_1.pt')
 
-    @patch("torch.save")
-    def test_state_dict(self, _):
-        check = _Checkpointer('test')
-        check.most_recent = 'temp'
-
-        state = check.state_dict()
-
-        check = _Checkpointer('test')
-        check.load_state_dict(state)
-        self.assertEqual(check.most_recent, 'temp')
-
 
 class TestModelCheckpoint(TestCase):
     def test_best_only(self):
@@ -180,7 +169,6 @@ class TestInterval(TestCase):
 
     def test_state_dict(self):
         check = Interval('test')
-        check.most_recent = 'temp'
         check.epochs_since_last_save = 10
 
         state = check.state_dict()
@@ -188,7 +176,6 @@ class TestInterval(TestCase):
         check = Interval('test')
         check.load_state_dict(state)
 
-        self.assertEqual(check.most_recent, 'temp')
         self.assertEqual(check.epochs_since_last_save, 10)
 
 
@@ -307,7 +294,6 @@ class TestBest(TestCase):
 
     def test_state_dict(self):
         check = Best('test')
-        check.most_recent = 'temp'
         check.best = 'temp2'
         check.epochs_since_last_save = 10
 
@@ -316,6 +302,5 @@ class TestBest(TestCase):
         check = Best('test')
         check.load_state_dict(state)
 
-        self.assertEqual(check.most_recent, 'temp')
         self.assertEqual(check.best, 'temp2')
         self.assertEqual(check.epochs_since_last_save, 10)

--- a/torchbearer/callbacks/checkpointers.py
+++ b/torchbearer/callbacks/checkpointers.py
@@ -19,14 +19,6 @@ class _Checkpointer(Callback):
         if fileformat.__contains__(os.sep) and not os.path.exists(os.path.dirname(fileformat)):
             os.makedirs(os.path.dirname(fileformat))
 
-    def state_dict(self):
-        return {'most_recent': self.most_recent}
-
-    def load_state_dict(self, state_dict):
-        self.most_recent = state_dict['most_recent']
-
-        return self
-
     def save_checkpoint(self, model_state, overwrite_most_recent=False):
         state = {}
         state.update(model_state)


### PR DESCRIPTION
Removes "most_recent" from state dict of checkpointers so they aren't removed after loading in model and resuming training. 
Temporary patch for  #412 
